### PR TITLE
Update Deploy to GitHub Pages

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -42,12 +42,10 @@ jobs:
 
       - name: Deploy to GH Pages
         if: success()
-        uses: crazy-max/ghaction-github-pages@v1
+        uses: crazy-max/ghaction-github-pages@v2.0.0
         with:
           target_branch: gh-pages
           build_dir: _site
-          committer_name: Octocat
-          committer_email: octocat@users.noreply.github.com
           fqdn: dev.twofactorauth.org
         env:
-          GITHUB_PAT: ${{ secrets.GH_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Updates workflow to latest version, removes customer committer name/address, and switches to using the [GitHub Token](https://help.github.com/en/actions/configuring-and-managing-workflows/authenticating-with-the-github_token) instead of a [Personal Access Token](https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line) stored as a repo secret.

If this PR is merged, [delete the GH_TOKEN secret from this repo](https://github.com/2factorauth/dev/settings/secrets), [delete the Personal Access Token used for this secret from your account](https://github.com/settings/tokens), and repeat these steps on your fork to update to the new configuration.